### PR TITLE
Add organization member management APIs

### DIFF
--- a/NETCore.Keycloak.Client.Tests/Modules/KcAuthorizationTests/KcProtectedResourcePolicyProviderTests.cs
+++ b/NETCore.Keycloak.Client.Tests/Modules/KcAuthorizationTests/KcProtectedResourcePolicyProviderTests.cs
@@ -87,9 +87,11 @@ public class KcProtectedResourcePolicyProviderTests
         string policyName = null;
 
         // Act & Assert
-        _ = await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            // ReSharper disable once AssignNullToNotNullAttribute
-            await _policyProvider.GetPolicyAsync(policyName).ConfigureAwait(false)).ConfigureAwait(false);
+        _ = await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+            async () =>
+                // ReSharper disable once AssignNullToNotNullAttribute
+                await _policyProvider.GetPolicyAsync(policyName).ConfigureAwait(false))
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/NETCore.Keycloak.Client.Tests/Modules/KcOrganizationTests/KcOrganizationMemberHappyPathTests.cs
+++ b/NETCore.Keycloak.Client.Tests/Modules/KcOrganizationTests/KcOrganizationMemberHappyPathTests.cs
@@ -1,0 +1,431 @@
+using System.Net;
+using NETCore.Keycloak.Client.Models.Organizations;
+using NETCore.Keycloak.Client.Models.Users;
+using NETCore.Keycloak.Client.Tests.Abstraction;
+using Newtonsoft.Json;
+
+namespace NETCore.Keycloak.Client.Tests.Modules.KcOrganizationTests;
+
+/// <summary>
+/// Contains integration tests for Keycloak organization member management operations.
+/// Tests the full lifecycle of organization members including adding, listing, retrieving,
+/// counting, getting member organizations, and removing members.
+/// Organizations are available in Keycloak 26 and above.
+/// </summary>
+[TestClass]
+[TestCategory("Sequential")]
+public class KcOrganizationMemberHappyPathTests : KcTestingModule
+{
+    /// <summary>
+    /// Represents the context of the current test.
+    /// </summary>
+    private const string TestContext = "GlobalContext";
+
+    /// <summary>
+    /// Gets or sets the Keycloak organization used for testing member operations.
+    /// </summary>
+    private static KcOrganization TestOrganization
+    {
+        get
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<KcOrganization>(
+                    Environment.GetEnvironmentVariable(
+                        $"{nameof(KcOrganizationMemberHappyPathTests)}_KC_ORGANIZATION") ?? string.Empty);
+            }
+            catch ( Exception e )
+            {
+                Assert.Fail(e.Message);
+                return null;
+            }
+        }
+        set => Environment.SetEnvironmentVariable(
+            $"{nameof(KcOrganizationMemberHappyPathTests)}_KC_ORGANIZATION",
+            JsonConvert.SerializeObject(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the Keycloak user used for testing member operations.
+    /// </summary>
+    private static KcUser TestUser
+    {
+        get
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<KcUser>(
+                    Environment.GetEnvironmentVariable(
+                        $"{nameof(KcOrganizationMemberHappyPathTests)}_KC_USER") ?? string.Empty);
+            }
+            catch ( Exception e )
+            {
+                Assert.Fail(e.Message);
+                return null;
+            }
+        }
+        set => Environment.SetEnvironmentVariable(
+            $"{nameof(KcOrganizationMemberHappyPathTests)}_KC_USER",
+            JsonConvert.SerializeObject(value));
+    }
+
+    /// <summary>
+    /// Sets up the test environment before each test execution.
+    /// </summary>
+    [TestInitialize]
+    public void Init() => Assert.IsNotNull(KeycloakRestClient.Organizations);
+
+    /// <summary>
+    /// Creates an organization and a user for the member tests.
+    /// </summary>
+    [TestMethod]
+    public async Task A_ShouldSetupOrganizationAndUser()
+    {
+        // Skip on Keycloak versions below 26 — organizations are not supported.
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        // Create an organization and user for member testing.
+        var organization = await CreateAndGetOrganizationAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(organization);
+        TestOrganization = organization;
+
+        // Create a user to be added as a member.
+        var user = await CreateAndGetRealmUserAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(user);
+        TestUser = user;
+    }
+
+    /// <summary>
+    /// Validates adding a user as a member of an organization.
+    /// </summary>
+    [TestMethod]
+    public async Task B_ShouldAddMemberToOrganization()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var addMemberResponse = await KeycloakRestClient.Organizations.AddMemberAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(addMemberResponse);
+        Assert.IsFalse(addMemberResponse.IsError);
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(addMemberResponse.MonitoringMetrics,
+            HttpStatusCode.Created, HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Validates listing members of an organization.
+    /// </summary>
+    [TestMethod]
+    public async Task C_ShouldGetOrganizationMembers()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var getMembersResponse = await KeycloakRestClient.Organizations.GetMembersAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(getMembersResponse);
+        Assert.IsFalse(getMembersResponse.IsError);
+        Assert.IsNotNull(getMembersResponse.Response);
+        Assert.IsTrue(getMembersResponse.Response.Any());
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(getMembersResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates listing members with a filter.
+    /// </summary>
+    [TestMethod]
+    public async Task D_ShouldGetOrganizationMembersWithFilter()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var getMembersResponse = await KeycloakRestClient.Organizations.GetMembersAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            new KcOrganizationMemberFilter
+            {
+                Search = TestUser.Email,
+                Exact = true,
+                Max = 10
+            }).ConfigureAwait(false);
+
+        Assert.IsNotNull(getMembersResponse);
+        Assert.IsFalse(getMembersResponse.IsError);
+        Assert.IsNotNull(getMembersResponse.Response);
+        Assert.IsTrue(getMembersResponse.Response.Any(m => m.Email == TestUser.Email));
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(getMembersResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates counting members of an organization.
+    /// </summary>
+    [TestMethod]
+    public async Task E_ShouldGetOrganizationMembersCount()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var countResponse = await KeycloakRestClient.Organizations.GetMembersCountAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(countResponse);
+        Assert.IsFalse(countResponse.IsError);
+        Assert.IsTrue(countResponse.Response > 0);
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(countResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates retrieving a specific member by ID.
+    /// </summary>
+    [TestMethod]
+    public async Task F_ShouldGetOrganizationMember()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var getMemberResponse = await KeycloakRestClient.Organizations.GetMemberAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(getMemberResponse);
+        Assert.IsFalse(getMemberResponse.IsError);
+        Assert.IsNotNull(getMemberResponse.Response);
+        Assert.IsInstanceOfType<KcUser>(getMemberResponse.Response);
+        Assert.AreEqual(TestUser.Email, getMemberResponse.Response.Email);
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(getMemberResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates retrieving organizations for a member within an organization context.
+    /// </summary>
+    [TestMethod]
+    public async Task G_ShouldGetMemberOrganizations()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var memberOrgsResponse = await KeycloakRestClient.Organizations.GetMemberOrganizationsAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(memberOrgsResponse);
+        Assert.IsFalse(memberOrgsResponse.IsError);
+        Assert.IsNotNull(memberOrgsResponse.Response);
+        Assert.IsTrue(memberOrgsResponse.Response.Any(o => o.Id == TestOrganization.Id));
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(memberOrgsResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates retrieving organizations for a user using the top-level endpoint.
+    /// </summary>
+    [TestMethod]
+    public async Task H_ShouldGetUserOrganizations()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var userOrgsResponse = await KeycloakRestClient.Organizations.GetUserOrganizationsAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(userOrgsResponse);
+        Assert.IsFalse(userOrgsResponse.IsError);
+        Assert.IsNotNull(userOrgsResponse.Response);
+        Assert.IsTrue(userOrgsResponse.Response.Any(o => o.Id == TestOrganization.Id));
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(userOrgsResponse.MonitoringMetrics,
+            HttpStatusCode.OK, HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Validates removing a member from an organization.
+    /// </summary>
+    [TestMethod]
+    public async Task I_ShouldRemoveMemberFromOrganization()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var removeMemberResponse = await KeycloakRestClient.Organizations.RemoveMemberAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(removeMemberResponse);
+        Assert.IsFalse(removeMemberResponse.IsError);
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(removeMemberResponse.MonitoringMetrics,
+            HttpStatusCode.NoContent, HttpMethod.Delete);
+    }
+
+    /// <summary>
+    /// Validates inviting an existing user to an organization.
+    /// This test requires SMTP to be configured in the Keycloak realm,
+    /// as the invite endpoint sends an email to the user.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("RequiresSMTP")]
+    public async Task J_ShouldInviteExistingUserToOrganization()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        var inviteResponse = await KeycloakRestClient.Organizations.InviteExistingUserAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(inviteResponse);
+
+        // The invite endpoint requires SMTP configuration.
+        // If SMTP is not configured, Keycloak returns 500 with "Failed to send invite email".
+        if ( inviteResponse.IsError &&
+             inviteResponse.ErrorMessage?.Contains("Failed to send invite email",
+                 StringComparison.OrdinalIgnoreCase) == true )
+        {
+            Assert.Inconclusive("Skipped — SMTP not configured in Keycloak realm.");
+        }
+
+        Assert.IsFalse(inviteResponse.IsError);
+
+        KcCommonAssertion.AssertResponseMonitoringMetrics(inviteResponse.MonitoringMetrics,
+            HttpStatusCode.NoContent, HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Cleans up by deleting the test user and organization.
+    /// </summary>
+    [TestMethod]
+    public async Task K_ShouldCleanup()
+    {
+        if ( GetKcMajorVersion() < 26 )
+        {
+            Assert.Inconclusive("Skipped — organizations require Keycloak 26 or above.");
+        }
+
+        Assert.IsNotNull(TestOrganization);
+        Assert.IsNotNull(TestUser);
+
+        var accessToken = await GetRealmAdminTokenAsync(TestContext).ConfigureAwait(false);
+        Assert.IsNotNull(accessToken);
+
+        // Delete the test user.
+        var deleteUserResponse = await KeycloakRestClient.Users.DeleteAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestUser.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(deleteUserResponse);
+        Assert.IsFalse(deleteUserResponse.IsError);
+
+        // Delete the test organization.
+        var deleteOrgResponse = await KeycloakRestClient.Organizations.DeleteAsync(
+            TestEnvironment.TestingRealm.Name,
+            accessToken.AccessToken,
+            TestOrganization.Id).ConfigureAwait(false);
+
+        Assert.IsNotNull(deleteOrgResponse);
+        Assert.IsFalse(deleteOrgResponse.IsError);
+    }
+}

--- a/NETCore.Keycloak.Client/HttpClients/Abstraction/IKcOrganizations.cs
+++ b/NETCore.Keycloak.Client/HttpClients/Abstraction/IKcOrganizations.cs
@@ -1,6 +1,7 @@
 using NETCore.Keycloak.Client.Exceptions;
 using NETCore.Keycloak.Client.Models;
 using NETCore.Keycloak.Client.Models.Organizations;
+using NETCore.Keycloak.Client.Models.Users;
 
 namespace NETCore.Keycloak.Client.HttpClients.Abstraction;
 
@@ -124,5 +125,196 @@ public interface IKcOrganizations
         string realm,
         string accessToken,
         KcOrganizationFilter filter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a user as a member of an organization in a specified Keycloak realm.
+    ///
+    /// POST /{realm}/organizations/{organizationId}/members
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="userId">The ID of the user to add as a member.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> indicating the result of the operation.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<object>> AddMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a paginated list of members of an organization in a specified Keycloak realm.
+    ///
+    /// GET /{realm}/organizations/{organizationId}/members
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="filter">Optional filter criteria for pagination and search.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> containing an enumerable of <see cref="KcUser"/> objects.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<IEnumerable<KcUser>>> GetMembersAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        KcOrganizationMemberFilter filter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the count of members in an organization in a specified Keycloak realm.
+    ///
+    /// GET /{realm}/organizations/{organizationId}/members/count
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> with the count of members.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<long>> GetMembersCountAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a specific member of an organization by their ID in a specified Keycloak realm.
+    ///
+    /// GET /{realm}/organizations/{organizationId}/members/{memberId}
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="memberId">The ID of the member to retrieve.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> containing the <see cref="KcUser"/> details.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<KcUser>> GetMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a member from an organization in a specified Keycloak realm.
+    ///
+    /// DELETE /{realm}/organizations/{organizationId}/members/{memberId}
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="memberId">The ID of the member to remove.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> indicating the result of the operation.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<object>> RemoveMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the organizations associated with a specific member within an organization context.
+    ///
+    /// GET /{realm}/organizations/{organizationId}/members/{memberId}/organizations
+    /// </summary>
+    /// <param name="realm">The Keycloak realm to query.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization context.</param>
+    /// <param name="memberId">The ID of the member whose organizations are being retrieved.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> containing an enumerable of <see cref="KcOrganization"/> objects.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<IEnumerable<KcOrganization>>> GetMemberOrganizationsAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the organizations associated with a user by their ID (top-level endpoint).
+    ///
+    /// GET /{realm}/organizations/members/{userId}/organizations
+    /// </summary>
+    /// <param name="realm">The Keycloak realm to query.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="userId">The ID of the user whose organizations are being retrieved.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> containing an enumerable of <see cref="KcOrganization"/> objects.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<IEnumerable<KcOrganization>>> GetUserOrganizationsAsync(
+        string realm,
+        string accessToken,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invites an existing user to an organization using the specified user ID.
+    ///
+    /// POST /{realm}/organizations/{organizationId}/members/invite-existing-user
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="userId">The ID of the existing user to invite.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> indicating the result of the operation.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<object>> InviteExistingUserAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invites an existing user or sends a registration link to a new user based on the provided e-mail address.
+    /// If the user with the given e-mail address exists, it sends an invitation link;
+    /// otherwise, it sends a registration link.
+    ///
+    /// POST /{realm}/organizations/{organizationId}/members/invite-user
+    /// </summary>
+    /// <param name="realm">The Keycloak realm where the organization exists.</param>
+    /// <param name="accessToken">The access token used for authentication.</param>
+    /// <param name="organizationId">The ID of the organization.</param>
+    /// <param name="email">The e-mail address of the user to invite.</param>
+    /// <param name="firstName">Optional first name of the user.</param>
+    /// <param name="lastName">Optional last name of the user.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KcResponse{T}"/> indicating the result of the operation.
+    /// </returns>
+    /// <exception cref="KcException">Thrown if any required parameter is null, empty, or invalid.</exception>
+    Task<KcResponse<object>> InviteUserAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string email,
+        string firstName = null,
+        string lastName = null,
         CancellationToken cancellationToken = default);
 }

--- a/NETCore.Keycloak.Client/HttpClients/Implementation/KcOrganizations.cs
+++ b/NETCore.Keycloak.Client/HttpClients/Implementation/KcOrganizations.cs
@@ -1,7 +1,10 @@
 using Microsoft.Extensions.Logging;
 using NETCore.Keycloak.Client.HttpClients.Abstraction;
 using NETCore.Keycloak.Client.Models;
+using NETCore.Keycloak.Client.Models.Common;
 using NETCore.Keycloak.Client.Models.Organizations;
+using NETCore.Keycloak.Client.Models.Users;
+using NETCore.Keycloak.Client.Utils;
 
 namespace NETCore.Keycloak.Client.HttpClients.Implementation;
 
@@ -138,5 +141,297 @@ internal sealed class KcOrganizations(string baseUrl,
             null,
             "application/json",
             cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.AddMemberAsync"/>
+    public Task<KcResponse<object>> AddMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(userId), userId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members";
+        return ProcessRequestAsync<object>(
+            url,
+            HttpMethod.Post,
+            accessToken,
+            "Unable to add member to organization",
+            userId,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.GetMembersAsync"/>
+    public Task<KcResponse<IEnumerable<KcUser>>> GetMembersAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        KcOrganizationMemberFilter filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        filter ??= new KcOrganizationMemberFilter();
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members{filter.BuildQuery()}";
+        return ProcessRequestAsync<IEnumerable<KcUser>>(
+            url,
+            HttpMethod.Get,
+            accessToken,
+            "Unable to get organization members",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.GetMembersCountAsync"/>
+    public Task<KcResponse<long>> GetMembersCountAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/count";
+        return ProcessRequestAsync<long>(
+            url,
+            HttpMethod.Get,
+            accessToken,
+            "Unable to count organization members",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.GetMemberAsync"/>
+    public Task<KcResponse<KcUser>> GetMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(memberId), memberId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/{memberId}";
+        return ProcessRequestAsync<KcUser>(
+            url,
+            HttpMethod.Get,
+            accessToken,
+            "Unable to get organization member",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.RemoveMemberAsync"/>
+    public Task<KcResponse<object>> RemoveMemberAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(memberId), memberId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/{memberId}";
+        return ProcessRequestAsync<object>(
+            url,
+            HttpMethod.Delete,
+            accessToken,
+            "Unable to remove member from organization",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.GetMemberOrganizationsAsync"/>
+    public Task<KcResponse<IEnumerable<KcOrganization>>> GetMemberOrganizationsAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(memberId), memberId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/{memberId}/organizations";
+        return ProcessRequestAsync<IEnumerable<KcOrganization>>(
+            url,
+            HttpMethod.Get,
+            accessToken,
+            "Unable to get member organizations",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.GetUserOrganizationsAsync"/>
+    public Task<KcResponse<IEnumerable<KcOrganization>>> GetUserOrganizationsAsync(
+        string realm,
+        string accessToken,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(userId), userId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/members/{userId}/organizations";
+        return ProcessRequestAsync<IEnumerable<KcOrganization>>(
+            url,
+            HttpMethod.Get,
+            accessToken,
+            "Unable to get user organizations",
+            null,
+            "application/json",
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.InviteExistingUserAsync"/>
+    public async Task<KcResponse<object>> InviteExistingUserAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(userId), userId);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/invite-existing-user";
+
+        try
+        {
+            using var response = await ExecuteRequest(async () =>
+            {
+                var client = CreateHttpClient();
+
+                using var form = new FormUrlEncodedContent(
+                    new Dictionary<string, string>
+                    {
+                        { "id", userId }
+                    });
+
+                _ = client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+
+                return await client.PostAsync(new Uri(url), form, cancellationToken)
+                    .ConfigureAwait(false);
+            }, new KcHttpMonitoringFallbackModel
+            {
+                Url = url,
+                HttpMethod = HttpMethod.Post
+            }).ConfigureAwait(false);
+
+            return await HandleAsync<object>(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch ( Exception e )
+        {
+            if ( Logger != null )
+            {
+                KcLoggerMessages.Error(Logger, "Unable to invite existing user to organization", e);
+            }
+
+            return new KcResponse<object>
+            {
+                IsError = true,
+                Exception = e,
+                ErrorMessage = e.Message,
+                MonitoringMetrics = new KcHttpApiMonitoringMetrics
+                {
+                    HttpMethod = HttpMethod.Post,
+                    Error = e.Message,
+                    Url = new Uri(url),
+                    RequestException = e
+                }
+            };
+        }
+    }
+
+    /// <inheritdoc cref="IKcOrganizations.InviteUserAsync"/>
+    public async Task<KcResponse<object>> InviteUserAsync(
+        string realm,
+        string accessToken,
+        string organizationId,
+        string email,
+        string firstName = null,
+        string lastName = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAccess(realm, accessToken);
+        ValidateRequiredString(nameof(organizationId), organizationId);
+        ValidateRequiredString(nameof(email), email);
+
+        var url = $"{BaseUrl}/{realm}/organizations/{organizationId}/members/invite-user";
+
+        try
+        {
+            using var response = await ExecuteRequest(async () =>
+            {
+                var client = CreateHttpClient();
+
+                var formData = new Dictionary<string, string>
+                {
+                    { "email", email }
+                };
+
+                if ( !string.IsNullOrWhiteSpace(firstName) )
+                {
+                    formData.Add("firstName", firstName);
+                }
+
+                if ( !string.IsNullOrWhiteSpace(lastName) )
+                {
+                    formData.Add("lastName", lastName);
+                }
+
+                using var form = new FormUrlEncodedContent(formData);
+
+                _ = client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+
+                return await client.PostAsync(new Uri(url), form, cancellationToken)
+                    .ConfigureAwait(false);
+            }, new KcHttpMonitoringFallbackModel
+            {
+                Url = url,
+                HttpMethod = HttpMethod.Post
+            }).ConfigureAwait(false);
+
+            return await HandleAsync<object>(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch ( Exception e )
+        {
+            if ( Logger != null )
+            {
+                KcLoggerMessages.Error(Logger, "Unable to invite user to organization", e);
+            }
+
+            return new KcResponse<object>
+            {
+                IsError = true,
+                Exception = e,
+                ErrorMessage = e.Message,
+                MonitoringMetrics = new KcHttpApiMonitoringMetrics
+                {
+                    HttpMethod = HttpMethod.Post,
+                    Error = e.Message,
+                    Url = new Uri(url),
+                    RequestException = e
+                }
+            };
+        }
     }
 }

--- a/NETCore.Keycloak.Client/Models/Organizations/KcOrganization.cs
+++ b/NETCore.Keycloak.Client/Models/Organizations/KcOrganization.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace NETCore.Keycloak.Client.Models.Organizations;
 
@@ -14,7 +14,7 @@ public sealed class KcOrganization
     /// <value>
     /// A string representing the unique identifier of the organization.
     /// </value>
-    [JsonPropertyName("id")]
+    [JsonProperty("id")]
     public string Id { get; set; }
 
     /// <summary>
@@ -23,7 +23,7 @@ public sealed class KcOrganization
     /// <value>
     /// A string representing the display name of the organization.
     /// </value>
-    [JsonPropertyName("name")]
+    [JsonProperty("name")]
     public string Name { get; set; }
 
     /// <summary>
@@ -32,7 +32,7 @@ public sealed class KcOrganization
     /// <value>
     /// A string representing an alternate identifier or alias for the organization.
     /// </value>
-    [JsonPropertyName("alias")]
+    [JsonProperty("alias")]
     public string Alias { get; set; }
 
     /// <summary>
@@ -42,7 +42,7 @@ public sealed class KcOrganization
     /// A nullable boolean that is true when the organization is enabled, false when disabled,
     /// or null if the enabled state is not set.
     /// </value>
-    [JsonPropertyName("enabled")]
+    [JsonProperty("enabled")]
     public bool? Enabled { get; set; }
 
     /// <summary>
@@ -51,7 +51,7 @@ public sealed class KcOrganization
     /// <value>
     /// A string containing a human-readable description for the organization.
     /// </value>
-    [JsonPropertyName("description")]
+    [JsonProperty("description")]
     public string Description { get; set; }
 
     /// <summary>
@@ -60,7 +60,7 @@ public sealed class KcOrganization
     /// <value>
     /// A string representing the redirect URL associated with the organization (for example, after login or registration flows).
     /// </value>
-    [JsonPropertyName("redirectUrl")]
+    [JsonProperty("redirectUrl")]
     public string RedirectUrl { get; set; }
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed class KcOrganization
     /// <value>
     /// A dictionary where the key is the attribute name and the value is a list of values for that attribute (Keycloak style).
     /// </value>
-    [JsonPropertyName("attributes")]
+    [JsonProperty("attributes")]
     public Dictionary<string, List<string>> Attributes { get; set; }
 
     /// <summary>
@@ -78,6 +78,6 @@ public sealed class KcOrganization
     /// <value>
     /// A collection of <see cref="KcOrganizationDomain"/> representing domains associated with the organization.
     /// </value>
-    [JsonPropertyName("domains")]
+    [JsonProperty("domains")]
     public ICollection<KcOrganizationDomain> Domains { get; set; } = [];
 }

--- a/NETCore.Keycloak.Client/Models/Organizations/KcOrganizationDomain.cs
+++ b/NETCore.Keycloak.Client/Models/Organizations/KcOrganizationDomain.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace NETCore.Keycloak.Client.Models.Organizations;
 
@@ -14,7 +14,7 @@ public sealed class KcOrganizationDomain
     /// <value>
     /// A string representing the domain name (for example, "example.com").
     /// </value>
-    [JsonPropertyName("name")]
+    [JsonProperty("name")]
     public string Name { get; set; }
 
     /// <summary>
@@ -24,6 +24,6 @@ public sealed class KcOrganizationDomain
     /// A nullable boolean indicating whether the domain has been verified by Keycloak. 
     /// True if verified; false if not; null if the verification state is unknown.
     /// </value>
-    [JsonPropertyName("verified")]
+    [JsonProperty("verified")]
     public bool? Verified { get; set; }
 }

--- a/NETCore.Keycloak.Client/Models/Organizations/KcOrganizationMemberFilter.cs
+++ b/NETCore.Keycloak.Client/Models/Organizations/KcOrganizationMemberFilter.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Text;
+using NETCore.Keycloak.Client.Models.Common;
+using Newtonsoft.Json;
+
+namespace NETCore.Keycloak.Client.Models.Organizations;
+
+/// <summary>
+/// Represents a filter for querying Keycloak organization members.
+/// </summary>
+public sealed class KcOrganizationMemberFilter : KcFilter
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the search parameter must match exactly.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the parameters must match exactly; otherwise, <c>false</c>.
+    /// </value>
+    [JsonProperty("exact")]
+    public bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets the membership type to filter by.
+    /// </summary>
+    /// <value>
+    /// A string representing the membership type filter.
+    /// </value>
+    [JsonProperty("membershipType")]
+    public string MembershipType { get; set; }
+
+    /// <summary>
+    /// Builds the query string based on the filter properties.
+    /// </summary>
+    /// <returns>
+    /// A string containing the query parameters to be appended to a URL.
+    /// </returns>
+    public new string BuildQuery()
+    {
+        var builder = new StringBuilder($"?max={Max}");
+
+        // Include pagination offset if specified
+        if ( First != null )
+        {
+            _ = builder.Append(CultureInfo.CurrentCulture,
+                $"&first={string.Create(CultureInfo.CurrentCulture, $"{First}").ToLower(CultureInfo.CurrentCulture)}");
+        }
+
+        // Include general search query if specified
+        if ( !string.IsNullOrWhiteSpace(Search) )
+        {
+            _ = builder.Append(CultureInfo.CurrentCulture, $"&search={Search}");
+        }
+
+        // Include exact match filter if specified
+        if ( Exact != null )
+        {
+            _ = builder.Append(CultureInfo.CurrentCulture,
+                $"&exact={Exact.ToString().ToLower(CultureInfo.CurrentCulture)}");
+        }
+
+        // Include membership type filter if specified
+        if ( !string.IsNullOrWhiteSpace(MembershipType) )
+        {
+            _ = builder.Append(CultureInfo.CurrentCulture, $"&membershipType={MembershipType}");
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds organization member management endpoints to the `IKcOrganizations` API and fixes a serialization bug in the organization models that prevents organization operations from working against Keycloak 26+.

### Bug Fix

`KcOrganization` and `KcOrganizationDomain` models used `System.Text.Json` attributes (`[JsonPropertyName]`), but the HTTP client base serializes request bodies with `Newtonsoft.Json` (`JsonConvert.SerializeObject`), which ignores those attributes. This caused property names to serialize as PascalCase (e.g., `"Name"` instead of `"name"`), resulting in `400 Bad Request` from Keycloak:

`Invalid json representation for OrganizationRepresentation. Unrecognized field "Name"`

Fixed by switching the two organization model files to use `[JsonProperty]` from Newtonsoft.Json, consistent with all other models in the library.

### New Features

Added 9 organization member management methods to `IKcOrganizations`:

| Method | HTTP | Endpoint |
|--------|------|----------|
| `AddMemberAsync` | POST | `/{realm}/organizations/{id}/members` |
| `GetMembersAsync` | GET | `/{realm}/organizations/{id}/members` |
| `GetMembersCountAsync` | GET | `/{realm}/organizations/{id}/members/count` |
| `GetMemberAsync` | GET | `/{realm}/organizations/{id}/members/{memberId}` |
| `RemoveMemberAsync` | DELETE | `/{realm}/organizations/{id}/members/{memberId}` |
| `GetMemberOrganizationsAsync` | GET | `/{realm}/organizations/{id}/members/{memberId}/organizations` |
| `GetUserOrganizationsAsync` | GET | `/{realm}/organizations/members/{userId}/organizations` |
| `InviteExistingUserAsync` | POST | `/{realm}/organizations/{id}/members/invite-existing-user` |
| `InviteUserAsync` | POST | `/{realm}/organizations/{id}/members/invite-user` |

Added `KcOrganizationMemberFilter` model for paginated member queries (supports `first`, `max`, `search`, `exact`, `membershipType`).

### Files Changed

- `KcOrganization.cs`, `KcOrganizationDomain.cs` — `[JsonPropertyName]` → `[JsonProperty]` (bug fix)
- `IKcOrganizations.cs` — 9 new method signatures
- `KcOrganizations.cs` — 9 new method implementations
- `KcOrganizationMemberFilter.cs` — new filter model
- `KcOrganizationMemberHappyPathTests.cs` — integration tests covering the full member lifecycle

### Testing

All 21 organization tests pass against Keycloak 26.5.1 (existing 10 + new 11, with `InviteExistingUser` skipped when SMTP is not configured).
